### PR TITLE
Add support for Salesforce Apex language

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -5,7 +5,8 @@ const filePatternToLanguage = {
   'directory.build.targets': 'markup',
   'directory.packages.props': 'markup',
   'nuget.config': 'markup',
-  '*.feature': 'gherkin'
+  '*.feature': 'gherkin',
+  '*.cls': 'apex'
 };
 
 function getLanguageFromFileName(fileName) {

--- a/content_script.js
+++ b/content_script.js
@@ -6,7 +6,7 @@ const filePatternToLanguage = {
   'directory.packages.props': 'markup',
   'nuget.config': 'markup',
   '*.feature': 'gherkin',
-  '*.cls': 'apex'
+  '*.(cls|trigger)': 'apex'
 };
 
 function getLanguageFromFileName(fileName) {


### PR DESCRIPTION
The extensions used by Apex files are .cls and .trigger