### PR TITLE
Multi-line based highlight instead of line per line

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -57,51 +57,65 @@ function processFileDiff(fileDiffElement) {
   }
 
   let fileNameElement = fileDiffElement.querySelector('.repos-change-summary-file-icon-container + .flex-column .text-ellipsis');
-
   const fileName = fileNameElement ? fileNameElement.textContent.trim() : null;
   const language = getLanguageFromFileName(fileName);
 
-  let originalLineElements = fileDiffElement.querySelectorAll('.monospaced-text > .repos-line-content');
+  if (!language || !Prism.languages[language]) {
+    return;
+  }
+
+  const originalLineElements = Array.from(fileDiffElement.querySelectorAll('.monospaced-text > .repos-line-content'));
+  const linesToHighlight = [];
+  const elementsToPreserveByLine = [];
 
   originalLineElements.forEach(originalLineElement => {
-    if (!originalLineElement.classList.contains('ado-syntax-highlighted')) {
+    const elementsToPreserve = [];
+    const nonCodeQuery = '.screen-reader-only, span[aria-hidden="true"]';
+    originalLineElement.querySelectorAll(nonCodeQuery).forEach(el => {
+      elementsToPreserve.push(el.cloneNode(true));
+    });
+    elementsToPreserveByLine.push(elementsToPreserve);
 
-      const elementsToPreserve = [];
-      const nonCodeQuery = '.screen-reader-only, span[aria-hidden="true"]';
-      originalLineElement.querySelectorAll(nonCodeQuery).forEach(el => {
-        elementsToPreserve.push(el.cloneNode(true));
+    const codeContainer = originalLineElement.cloneNode(true);
+    codeContainer.querySelectorAll(nonCodeQuery).forEach(el => el.remove());
+
+    linesToHighlight.push(codeContainer.innerHTML);
+  });
+
+  if (linesToHighlight.length === 0) {
+    return;
+  }
+
+  const code = document.createElement('code');
+  code.className = `language-${language}`;
+  code.innerHTML = linesToHighlight.join('\n');
+
+  Prism.highlightElement(code, false, () => {
+    const highlightedLinesHTML = code.innerHTML.split('\n');
+
+    highlightedLinesHTML.forEach((highlightedLineHTML, index) => {
+      const originalLineElement = originalLineElements[index];
+      if (!originalLineElement) return;
+
+      const newLineElement = originalLineElement.cloneNode(false);
+      newLineElement.innerHTML = '';
+      newLineElement.classList.add('ado-syntax-highlighted');
+      newLineElement.classList.add(getTheme(originalLineElement));
+
+      elementsToPreserveByLine[index].forEach(el => {
+        newLineElement.appendChild(el);
       });
 
-      const codeContainer = originalLineElement.cloneNode(true);
-      codeContainer.querySelectorAll(nonCodeQuery).forEach(el => el.remove());
-      const codeToHighlight = codeContainer.innerHTML;
+      const codeWrapper = document.createElement('span');
+      codeWrapper.innerHTML = highlightedLineHTML;
+      newLineElement.appendChild(codeWrapper);
 
-      const highlightedLine = originalLineElement.cloneNode(true);
+      // Hide the original line
+      originalLineElement.style.display = 'none';
+      originalLineElement.classList.add('ado-syntax-highlighted-original');
 
-      const code = document.createElement('code'); // Temporary element
-      code.className = `language-${language}`;
-      code.innerHTML =  codeToHighlight;
-      Prism.highlightElement(code, false, () => {
-        const contentDiv = document.createElement('div');
-        contentDiv.innerHTML = code.innerHTML;
-        contentDiv.classList.add(getTheme(originalLineElement));
-        highlightedLine.innerHTML = '';
-
-        elementsToPreserve.forEach(el => {
-          highlightedLine.appendChild(el);
-        });
-
-        highlightedLine.appendChild(contentDiv);
-        highlightedLine.classList.add('ado-syntax-highlighted');
-
-        // Hide the original line.
-        // This is a hack to make the line comment button functional. Otherwise it breaks.
-        originalLineElement.style.display = 'none';
-
-        // Insert the highlighted version after the original
-        originalLineElement.parentNode.insertBefore(highlightedLine, originalLineElement.nextSibling)
-      });
-    }
+      originalLineElement.parentNode.insertBefore(newLineElement, originalLineElement.nextSibling);
+    });
   });
 }
 


### PR DESCRIPTION
Fixes multiline syntax highlight such as in multi-line comments or multiline string raw literals in some languages.