### PR TITLE
Add highlighting support for single-file and diff views

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -6,7 +6,9 @@ const defaultFilePatternToLanguage = {
   'directory.packages.props': 'markup',
   'nuget.config': 'markup',
   '*.feature': 'gherkin',
-  '*.(cls|trigger)': 'apex'
+  '*.(cls|trigger)': 'apex',
+  '*.tfvars': 'hcl',
+  '*.tf': 'hcl'
 };
 
 // Custom patterns loaded from storage (takes priority)
@@ -136,6 +138,302 @@ function processFileDiff(fileDiffElement) {
   });
 }
 
+function getFileNameFromHeading() {
+  const heading = document.querySelector('.repos-compare-toolbar span.text-ellipsis[role="heading"]');
+
+  return heading ? heading.textContent.trim() : null;
+}
+
+/**
+ * Flatten Prism's token stream into a flat array of `{ text, classes }` entries.
+ *
+ * `Prism.tokenize()` returns a `TokenStream`: an array of strings (plain text)
+ * and Token objects (with `.type`, `.content`, `.alias`). Tokens can nest; their
+ * `.content` can itself be a `TokenStream`. This function recursively flattens
+ * that into a simple sequence of leaf text segments, each annotated with the
+ * full set of CSS classes it would receive (e.g. `['token', 'keyword']`).
+ *
+ * @param {Array} tokens - Prism token stream from `Prism.tokenize()`
+ * @returns {Array<{text: string, classes: string[]}>}
+ */
+function flattenPrismTokenStream(tokens) {
+  const result = [];
+
+  function walk(tokenOrString, inheritedClasses) {
+    if (typeof tokenOrString === 'string') {
+      if (tokenOrString.length > 0) {
+        result.push({ text: tokenOrString, classes: [...inheritedClasses] });
+      }
+
+      return;
+    }
+
+    // It's a Prism Token object with .type, .content, .alias
+    const token = tokenOrString;
+    const classes = [...inheritedClasses, 'token', token.type];
+    if (token.alias) {
+      if (Array.isArray(token.alias)) {
+        classes.push(...token.alias);
+      } else {
+        classes.push(token.alias);
+      }
+    }
+
+    if (typeof token.content === 'string') {
+      if (token.content.length > 0) {
+        result.push({ text: token.content, classes });
+      }
+    } else if (Array.isArray(token.content)) {
+      for (const child of token.content) {
+        walk(child, classes);
+      }
+    } else if (token.content) {
+      // Single nested Token (not wrapped in an array)
+      walk(token.content, classes);
+    }
+  }
+
+  for (const t of tokens) {
+    walk(t, []);
+  }
+
+  return result;
+}
+
+/**
+ * Cache of resolved Prism token colors per theme.
+ *
+ * Structure: Map<themeClass, Map<classListKey, string|null>>
+ *
+ * We create a hidden element with the theme class and probe computed colors
+ * for each unique set of Prism token classes. This is cached so each unique
+ * token class combination is resolved at most once per theme per page load.
+ */
+const prismColorCache = new Map();
+
+/**
+ * Get a hidden probe element for resolving Prism token colors.
+ * The probe is a <div> with the theme class attached to it, appended to
+ * document.body but invisible. Token color probes are created as children.
+ */
+const themeProbes = new Map();
+
+function getThemeProbe(themeClass) {
+  if (themeProbes.has(themeClass)) {
+    return themeProbes.get(themeClass);
+  }
+
+  const probe = document.createElement('div');
+  probe.className = themeClass;
+  probe.style.cssText = 'position:absolute;left:-9999px;top:-9999px;visibility:hidden;pointer-events:none;';
+  document.body.appendChild(probe);
+  themeProbes.set(themeClass, probe);
+
+  return probe;
+}
+
+/**
+ * Resolve the CSS color for a set of Prism token classes under a given theme.
+ *
+ * The theme CSS (built by Makefile) wraps each Prism theme inside a scoping
+ * class like `.prism-one-light { .token.keyword { color: ... } }`. By placing
+ * a probe element inside a container with that theme class, getComputedStyle
+ * will resolve the correct color.
+ *
+ * @param {string[]} classes - Prism token classes (e.g. ['token', 'keyword'])
+ * @param {string} themeClass - Theme scope class (e.g. 'prism-one-light')
+ * @returns {string|null} - Resolved CSS color string, or null if no override
+ */
+function resolvePrismColor(classes, themeClass) {
+  if (!prismColorCache.has(themeClass)) {
+    prismColorCache.set(themeClass, new Map());
+  }
+
+  const cache = prismColorCache.get(themeClass);
+  const key = classes.join(' ');
+  if (cache.has(key)) {
+    return cache.get(key);
+  }
+
+  const probe = getThemeProbe(themeClass);
+  const span = document.createElement('span');
+
+  for (const cls of classes) {
+    span.classList.add(cls);
+  }
+
+  probe.appendChild(span);
+  const resolved = window.getComputedStyle(span).color;
+  probe.removeChild(span);
+
+  // Compare against the probe container's own color (the "no override" baseline).
+  // If the resolved color matches the container's default, Prism has no specific
+  // rule for this token type, so return null to leave Monaco's color intact.
+  const baseColor = window.getComputedStyle(probe).color;
+  const color = (resolved && resolved !== baseColor) ? resolved : null;
+  cache.set(key, color);
+
+  return color;
+}
+
+/**
+ * Get a plain-text fingerprint for a Monaco .view-line element,
+ * used to detect when Monaco has recycled a node with new content.
+ * This uses the raw textContent which is fast and avoids full parsing.
+ */
+function getMonacoLineFingerprint(viewLineElement) {
+  const lineSpan = viewLineElement.querySelector('span');
+
+  return lineSpan ? lineSpan.textContent : '';
+}
+
+/**
+ * Process all visible lines within a single Monaco `.view-lines` container.
+ * Monaco virtualizes lines (only renders visible ones), so this function
+ * is called repeatedly as the user scrolls.
+ *
+ * CSS-only approach: instead of replacing Monaco's DOM (which breaks mouse
+ * hit-testing due to `className` checks and stale `CharacterMapping`), we:
+ * 1. Extract the line's plain text
+ * 2. Tokenize with `Prism.tokenize()` to get token types + character ranges
+ * 3. Walk Monaco's existing mtk* spans and apply inline color styles
+ *    based on which Prism token covers each span's characters
+ * 4. Never modify DOM structure (Monaco's hit-testing stays intact)
+ */
+function processMonacoViewLines(viewLinesElement, language, themeClass) {
+  const grammar = Prism.languages[language];
+  if (!grammar) {
+    return;
+  }
+
+  const viewLines = viewLinesElement.querySelectorAll('.view-line');
+
+  viewLines.forEach(viewLine => {
+    const fingerprint = getMonacoLineFingerprint(viewLine);
+
+    if (viewLine.dataset.adoHighlightedText === fingerprint) {
+      return; // Content unchanged, skip
+    }
+
+    // Get the inner span wrapper that contains token spans
+    const lineSpan = viewLine.querySelector('span');
+    if (!lineSpan) {
+      return;
+    }
+
+    // 1. Extract plain text from the line for Prism tokenization.
+    // We need to map character positions between Monaco spans and Prism tokens.
+    // Build an array of { node, startOffset, length } for each Monaco child span.
+    const monacoSpans = [];
+    let totalLength = 0;
+    for (const child of lineSpan.childNodes) {
+      if (child.nodeType === Node.TEXT_NODE) {
+        const len = child.textContent.length;
+        if (len > 0) {
+          monacoSpans.push({ node: child, start: totalLength, length: len, isWhitespace: false });
+          totalLength += len;
+        }
+      } else if (child.nodeType === Node.ELEMENT_NODE) {
+        const text = child.textContent;
+        const len = text.length;
+        const isWhitespace = child.classList.contains('mtkw');
+        if (len > 0) {
+          monacoSpans.push({ node: child, start: totalLength, length: len, isWhitespace });
+          totalLength += len;
+        }
+      }
+    }
+
+    if (monacoSpans.length === 0) {
+      return;
+    }
+
+    // Build the full plain text. For whitespace spans, substitute actual spaces
+    // so Prism sees syntactically valid code (Monaco uses · and → glyphs).
+    let plainText = '';
+    for (const ms of monacoSpans) {
+      if (ms.isWhitespace) {
+        plainText += ' '.repeat(ms.length);
+      } else {
+        plainText += ms.node.textContent;
+      }
+    }
+
+    // 2. Tokenize with Prism
+    const tokens = Prism.tokenize(plainText, grammar);
+    const flatTokens = flattenPrismTokenStream(tokens);
+
+    // 3. Build a character→color map from the flat Prism tokens.
+    // Each flat token has { text, classes } and covers a contiguous character range.
+    const tokenColors = [];
+    let tokenOffset = 0;
+    for (const ft of flatTokens) {
+      const color = ft.classes.length > 0 ? resolvePrismColor(ft.classes, themeClass) : null;
+      tokenColors.push({ start: tokenOffset, end: tokenOffset + ft.text.length, color });
+      tokenOffset += ft.text.length;
+    }
+
+    // 4. For each Monaco span, find the Prism color that covers it.
+    // If a Monaco span straddles multiple Prism tokens with different colors,
+    // we use the color at the start of the span (the dominant visual token).
+    // This is a pragmatic trade-off: splitting spans would break CharacterMapping.
+    let tokenIdx = 0;
+    for (const ms of monacoSpans) {
+      if (ms.isWhitespace) {
+        continue; // Don't color whitespace markers
+      }
+      if (ms.node.nodeType !== Node.ELEMENT_NODE) {
+        continue; // Skip bare text nodes
+      }
+
+      const spanStart = ms.start;
+
+      // Advance tokenIdx to the Prism token that covers spanStart
+      while (tokenIdx < tokenColors.length && tokenColors[tokenIdx].end <= spanStart) {
+        tokenIdx++;
+      }
+
+      if (tokenIdx < tokenColors.length && tokenColors[tokenIdx].color) {
+        ms.node.style.color = tokenColors[tokenIdx].color;
+      } else {
+        // No Prism override — remove any previously applied color
+        ms.node.style.removeProperty('color');
+      }
+    }
+
+    // Mark as highlighted (using data attribute only, no class changes on .view-line)
+    viewLine.dataset.adoHighlightedText = fingerprint;
+  });
+}
+
+/**
+ * Find and process all Monaco editor views on the page.
+ * This handles both diff views (side-by-side or inline, with two `.view-lines`
+ * containers) and non-diff views (e.g. new files with a single `.view-lines`
+ * container). By targeting `.view-lines` directly, the same logic works for
+ * any Monaco editor regardless of the surrounding container structure.
+ */
+function processMonacoEditors() {
+  const fileName = getFileNameFromHeading();
+  const language = getLanguageFromFileName(fileName);
+  if (!language) {
+    console.debug('ADO Syntax Highlighter: Could not determine language for Monaco editor:', fileName);
+
+    return;
+  }
+
+  const viewLinesContainers = document.querySelectorAll('.view-lines');
+  viewLinesContainers.forEach(container => {
+    const firstLine = container.querySelector('.view-line');
+    if (!firstLine) {
+      return;
+    }
+
+    const themeClass = getTheme(firstLine);
+    processMonacoViewLines(container, language, themeClass);
+  });
+}
+
 function applySyntaxHighlighting() {
   if (!window.location.href.includes('/_git/')) {
     return;
@@ -147,6 +445,8 @@ function applySyntaxHighlighting() {
   fileDiffPanels.forEach(fileDiffPanel => {
     processFileDiff(fileDiffPanel);
   });
+
+  processMonacoEditors();
 }
 
 console.debug("ADO Syntax Highlighter: Content script loaded.");
@@ -172,21 +472,74 @@ const debouncedApplyHighlighting = debounce(applySyntaxHighlighting, 250);
 // Listen for URL changes
 window.addEventListener('popstate', debouncedApplyHighlighting);
 
+// Selectors that trigger re-highlighting when new matching elements appear in the DOM.
+// Summary diff view selectors:
+//   .repos-summary-code-diff, .repos-diff-contents-row, .bolt-card - summary diff cards
+// Single-file view selectors:
+//   .vc-diff-viewer, .diff-frame - diff viewer containers
+//   .repos-pr-iteration-file-header - file header when switching files/iterations
+//   .repos-diff-editor - Monaco diff editor container
+const MUTATION_TRIGGER_SELECTOR = [
+  '.repos-summary-code-diff',
+  '.vc-diff-viewer',
+  '.diff-frame',
+  '.repos-diff-contents-row',
+  '.bolt-card',
+  '.repos-pr-iteration-file-header',
+  '.repos-diff-editor'
+].join(', ');
+
+// Monaco virtualizes lines: only visible lines are in the DOM, and they are
+// added/removed/recycled as the user scrolls. Use requestAnimationFrame
+// to process new lines on the next paint frame rather than waiting a fixed
+// debounce delay. Multiple mutations within the same frame are coalesced
+// into a single rAF callback (~16ms at 60fps vs the old 100ms debounce).
+let monacoRafPending = false;
+function scheduleMonacoHighlighting() {
+  if (monacoRafPending) {
+    return;
+  }
+
+  monacoRafPending = true;
+  requestAnimationFrame(() => {
+    monacoRafPending = false;
+    if (!window.location.href.includes('/_git/')) {
+      return;
+    }
+
+    processMonacoEditors();
+  });
+}
+
 // Observe DOM changes for dynamically loaded content
 new MutationObserver((mutationsList) => {
   for (const mutation of mutationsList) {
     if (!(mutation.type === 'childList' && mutation.addedNodes.length > 0)) {
       continue;
     }
+
     for (const node of mutation.addedNodes) {
       if (node.nodeType !== Node.ELEMENT_NODE) {
         continue;
       }
+
+      // Check for Monaco line additions (.view-line inside .view-lines)
+      // This handles scroll virtualization where Monaco adds new lines dynamically.
       if (
-        node.matches?.('.repos-summary-code-diff, .vc-diff-viewer, .diff-frame, .repos-diff-contents-row, .bolt-card, .repos-pr-iteration-file-header') ||
-        node.querySelector?.('.repos-summary-code-diff, .vc-diff-viewer, .diff-frame, .repos-diff-contents-row, .bolt-card, .repos-pr-iteration-file-header')
+        node.matches?.('.view-line') ||
+        node.querySelector?.('.view-line')
+      ) {
+        scheduleMonacoHighlighting();
+        // Don't return here — also check for structural changes below
+      }
+
+      // Check for structural diff container changes
+      if (
+        node.matches?.(MUTATION_TRIGGER_SELECTOR) ||
+        node.querySelector?.(MUTATION_TRIGGER_SELECTOR)
       ) {
         debouncedApplyHighlighting();
+
         return;
       }
     }

--- a/content_script.js
+++ b/content_script.js
@@ -205,7 +205,7 @@ function flattenPrismTokenStream(tokens) {
  *
  * Structure: Map<themeClass, Map<classListKey, string|null>>
  *
- * We create a hidden element with the theme class and probe computed colors
+ * Create a hidden element with the theme class and probe computed colors
  * for each unique set of Prism token classes. This is cached so each unique
  * token class combination is resolved at most once per theme per page load.
  */
@@ -322,7 +322,7 @@ function processMonacoViewLines(viewLinesElement, language, themeClass) {
     }
 
     // 1. Extract plain text from the line for Prism tokenization.
-    // We need to map character positions between Monaco spans and Prism tokens.
+    // Map character positions between Monaco spans and Prism tokens.
     // Build an array of { node, startOffset, length } for each Monaco child span.
     const monacoSpans = [];
     let totalLength = 0;
@@ -375,7 +375,7 @@ function processMonacoViewLines(viewLinesElement, language, themeClass) {
 
     // 4. For each Monaco span, find the Prism color that covers it.
     // If a Monaco span straddles multiple Prism tokens with different colors,
-    // we use the color at the start of the span (the dominant visual token).
+    // use the color at the start of the span (the dominant visual token).
     // This is a pragmatic trade-off: splitting spans would break CharacterMapping.
     let tokenIdx = 0;
     for (const ms of monacoSpans) {

--- a/content_script.js
+++ b/content_script.js
@@ -293,7 +293,7 @@ function getMonacoLineFingerprint(viewLineElement) {
  * is called repeatedly as the user scrolls.
  *
  * CSS-only approach: instead of replacing Monaco's DOM (which breaks mouse
- * hit-testing due to `className` checks and stale `CharacterMapping`), we:
+ * hit-testing due to `className` checks and stale `CharacterMapping`):
  * 1. Extract the line's plain text
  * 2. Tokenize with `Prism.tokenize()` to get token types + character ranges
  * 3. Walk Monaco's existing mtk* spans and apply inline color styles

--- a/options.html
+++ b/options.html
@@ -18,11 +18,15 @@
       <br>
       <small>Themes from <a href="https://github.com/PrismJS/prism-themes" target="_blank">prism-themes</a> and <a
           href="https://prismjs.com/download.html#themes=prism" target="_blank">PrismJS Download</a>.</small>
+      <small>Themes from <a href="https://github.com/PrismJS/prism-themes" target="_blank">prism-themes</a>, <a
+          href="https://prismjs.com/download.html#themes=prism" target="_blank">PrismJS Download</a>, and <a
+          href="https://github.com/catppuccin/prismjs" target="_blank">Catppuccin</a>.</small>
     </p>
     <select id="theme-select">
       <option value="auto">Automatic (Default)</option>
       <optgroup label="Light Mode">
         <option value="prism-base16-ateliersulphurpool-light">Ateliersulphurpool-Light</option>
+        <option value="prism-catppuccin-latte">Catppuccin Latte</option>
         <option value="prism-coldark-cold">Coldark Cold</option>
         <option value="prism-coy-without-shadows">Coy without shadows</option>
         <option value="prism-coy">Coy</option>
@@ -39,6 +43,9 @@
         <option value="prism-a11y-dark">a11y Dark</option>
         <option value="prism-atom-dark">Atom Dark</option>
         <option value="prism-cb">CB</option>
+        <option value="prism-catppuccin-frappe">Catppuccin Frapp&#233;</option>
+        <option value="prism-catppuccin-macchiato">Catppuccin Macchiato</option>
+        <option value="prism-catppuccin-mocha">Catppuccin Mocha</option>
         <option value="prism-coldark-dark">Coldark Dark</option>
         <option value="prism-darcula">Darcula</option>
         <option value="prism-dark">Dark</option>

--- a/prism/themes/prism-catppuccin-frappe.css
+++ b/prism/themes/prism-catppuccin-frappe.css
@@ -1,0 +1,134 @@
+code[class*="language-"],
+pre[class*="language-"] {
+	color: #c6d0f5;
+}
+
+:not(pre) > code[class*="language-"],
+pre[class*="language-"] {
+	background: #292c3c;
+}
+
+/* https://prismjs.com/tokens.html */
+
+.token.keyword {
+	color: #ca9ee6;
+}
+
+.token.builtin {
+	color: #e78284;
+}
+
+.token.class-name {
+	color: #e5c890;
+}
+
+.token.function {
+	color: #8caaee;
+}
+
+.token.boolean,
+.token.number {
+	color: #ef9f76;
+}
+
+.token.string,
+.token.char {
+	color: #a6d189;
+}
+
+.token.symbol {
+	color: #e5c890;
+}
+
+.token.regex {
+	color: #f4b8e4;
+}
+
+.token.url {
+	color: #a6d189;
+}
+
+.token.operator {
+	color: #99d1db;
+}
+
+.token.variable {
+	color: #c6d0f5;
+}
+
+.token.constant {
+	color: #ef9f76;
+}
+
+.token.property {
+	color: #8caaee;
+}
+
+.token.punctuation {
+	color: #949cbb;
+}
+
+.token.important {
+	color: #ca9ee6;
+}
+
+.token.comment {
+	color: #949cbb;
+}
+
+.token.tag {
+	color: #8caaee;
+}
+
+.token.attr-name {
+	color: #e5c890;
+}
+
+.token.attr-value {
+	color: #a6d189;
+}
+
+.token.namespace {
+	color: #e5c890;
+}
+
+.token.prolog,
+.token.doctype {
+	color: #ca9ee6;
+}
+
+.token.cdata {
+	color: #81c8be;
+}
+
+.token.entity {
+	color: #e78284;
+}
+
+.token.atrule {
+	color: #ca9ee6;
+}
+
+.token.selector {
+	color: #8caaee;
+}
+
+/* Diff */
+
+.token.deleted {
+	color: #e78284;
+}
+
+.token.inserted {
+	color: #a6d189
+}
+
+/* Other */
+
+.token.important,
+.token.bold {
+	font-weight: bold;
+}
+.token.italic {
+	font-style: italic;
+}

--- a/prism/themes/prism-catppuccin-latte.css
+++ b/prism/themes/prism-catppuccin-latte.css
@@ -1,0 +1,134 @@
+code[class*="language-"],
+pre[class*="language-"] {
+	color: #4c4f69;
+}
+
+:not(pre) > code[class*="language-"],
+pre[class*="language-"] {
+	background: #e6e9ef;
+}
+
+/* https://prismjs.com/tokens.html */
+
+.token.keyword {
+	color: #8839ef;
+}
+
+.token.builtin {
+	color: #d20f39;
+}
+
+.token.class-name {
+	color: #df8e1d;
+}
+
+.token.function {
+	color: #1e66f5;
+}
+
+.token.boolean,
+.token.number {
+	color: #fe640b;
+}
+
+.token.string,
+.token.char {
+	color: #40a02b;
+}
+
+.token.symbol {
+	color: #df8e1d;
+}
+
+.token.regex {
+	color: #ea76cb;
+}
+
+.token.url {
+	color: #40a02b;
+}
+
+.token.operator {
+	color: #04a5e5;
+}
+
+.token.variable {
+	color: #4c4f69;
+}
+
+.token.constant {
+	color: #fe640b;
+}
+
+.token.property {
+	color: #1e66f5;
+}
+
+.token.punctuation {
+	color: #7c7f93;
+}
+
+.token.important {
+	color: #8839ef;
+}
+
+.token.comment {
+	color: #7c7f93;
+}
+
+.token.tag {
+	color: #1e66f5;
+}
+
+.token.attr-name {
+	color: #df8e1d;
+}
+
+.token.attr-value {
+	color: #40a02b;
+}
+
+.token.namespace {
+	color: #df8e1d;
+}
+
+.token.prolog,
+.token.doctype {
+	color: #8839ef;
+}
+
+.token.cdata {
+	color: #179299;
+}
+
+.token.entity {
+	color: #d20f39;
+}
+
+.token.atrule {
+	color: #8839ef;
+}
+
+.token.selector {
+	color: #1e66f5;
+}
+
+/* Diff */
+
+.token.deleted {
+	color: #d20f39;
+}
+
+.token.inserted {
+	color: #40a02b
+}
+
+/* Other */
+
+.token.important,
+.token.bold {
+	font-weight: bold;
+}
+.token.italic {
+	font-style: italic;
+}

--- a/prism/themes/prism-catppuccin-macchiato.css
+++ b/prism/themes/prism-catppuccin-macchiato.css
@@ -1,0 +1,134 @@
+code[class*="language-"],
+pre[class*="language-"] {
+	color: #cad3f5;
+}
+
+:not(pre) > code[class*="language-"],
+pre[class*="language-"] {
+	background: #1e2030;
+}
+
+/* https://prismjs.com/tokens.html */
+
+.token.keyword {
+	color: #c6a0f6;
+}
+
+.token.builtin {
+	color: #ed8796;
+}
+
+.token.class-name {
+	color: #eed49f;
+}
+
+.token.function {
+	color: #8aadf4;
+}
+
+.token.boolean,
+.token.number {
+	color: #f5a97f;
+}
+
+.token.string,
+.token.char {
+	color: #a6da95;
+}
+
+.token.symbol {
+	color: #eed49f;
+}
+
+.token.regex {
+	color: #f5bde6;
+}
+
+.token.url {
+	color: #a6da95;
+}
+
+.token.operator {
+	color: #91d7e3;
+}
+
+.token.variable {
+	color: #cad3f5;
+}
+
+.token.constant {
+	color: #f5a97f;
+}
+
+.token.property {
+	color: #8aadf4;
+}
+
+.token.punctuation {
+	color: #939ab7;
+}
+
+.token.important {
+	color: #c6a0f6;
+}
+
+.token.comment {
+	color: #939ab7;
+}
+
+.token.tag {
+	color: #8aadf4;
+}
+
+.token.attr-name {
+	color: #eed49f;
+}
+
+.token.attr-value {
+	color: #a6da95;
+}
+
+.token.namespace {
+	color: #eed49f;
+}
+
+.token.prolog,
+.token.doctype {
+	color: #c6a0f6;
+}
+
+.token.cdata {
+	color: #8bd5ca;
+}
+
+.token.entity {
+	color: #ed8796;
+}
+
+.token.atrule {
+	color: #c6a0f6;
+}
+
+.token.selector {
+	color: #8aadf4;
+}
+
+/* Diff */
+
+.token.deleted {
+	color: #ed8796;
+}
+
+.token.inserted {
+	color: #a6da95
+}
+
+/* Other */
+
+.token.important,
+.token.bold {
+	font-weight: bold;
+}
+.token.italic {
+	font-style: italic;
+}

--- a/prism/themes/prism-catppuccin-mocha.css
+++ b/prism/themes/prism-catppuccin-mocha.css
@@ -1,0 +1,134 @@
+code[class*="language-"],
+pre[class*="language-"] {
+	color: #cdd6f4;
+}
+
+:not(pre) > code[class*="language-"],
+pre[class*="language-"] {
+	background: #181825;
+}
+
+/* https://prismjs.com/tokens.html */
+
+.token.keyword {
+	color: #cba6f7;
+}
+
+.token.builtin {
+	color: #f38ba8;
+}
+
+.token.class-name {
+	color: #f9e2af;
+}
+
+.token.function {
+	color: #89b4fa;
+}
+
+.token.boolean,
+.token.number {
+	color: #fab387;
+}
+
+.token.string,
+.token.char {
+	color: #a6e3a1;
+}
+
+.token.symbol {
+	color: #f9e2af;
+}
+
+.token.regex {
+	color: #f5c2e7;
+}
+
+.token.url {
+	color: #a6e3a1;
+}
+
+.token.operator {
+	color: #89dceb;
+}
+
+.token.variable {
+	color: #cdd6f4;
+}
+
+.token.constant {
+	color: #fab387;
+}
+
+.token.property {
+	color: #89b4fa;
+}
+
+.token.punctuation {
+	color: #9399b2;
+}
+
+.token.important {
+	color: #cba6f7;
+}
+
+.token.comment {
+	color: #9399b2;
+}
+
+.token.tag {
+	color: #89b4fa;
+}
+
+.token.attr-name {
+	color: #f9e2af;
+}
+
+.token.attr-value {
+	color: #a6e3a1;
+}
+
+.token.namespace {
+	color: #f9e2af;
+}
+
+.token.prolog,
+.token.doctype {
+	color: #cba6f7;
+}
+
+.token.cdata {
+	color: #94e2d5;
+}
+
+.token.entity {
+	color: #f38ba8;
+}
+
+.token.atrule {
+	color: #cba6f7;
+}
+
+.token.selector {
+	color: #89b4fa;
+}
+
+/* Diff */
+
+.token.deleted {
+	color: #f38ba8;
+}
+
+.token.inserted {
+	color: #a6e3a1
+}
+
+/* Other */
+
+.token.important,
+.token.bold {
+	font-weight: bold;
+}
+.token.italic {
+	font-style: italic;
+}


### PR DESCRIPTION
# Add highlighting support for single-file and diff views

This PR adds syntax highlighting to Monaco-based editors which can be found on the single-file and diff views. Highlighting works in all modes, inline or side-by-side.

It also improves responsiveness - does away with the 100ms timeout and batches mutations to be rendered on the next paint instead. This brings latency down to around ~16ms at 60fps, rendering the new colors virtually instantly.

MISC
- Adds support for `.tf` and `.tfvars` (OpenTofu) files
- Adds all 4 catppuccin themes

This PR aims to fix #21.